### PR TITLE
libc/misc: Mark lock functions as weak

### DIFF
--- a/newlib/libc/misc/lock.c
+++ b/newlib/libc/misc/lock.c
@@ -81,51 +81,52 @@ struct __lock {
   char unused;
 };
 
+__attribute__ ((weak))
 struct __lock __lock___libc_recursive_mutex;
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_init (_LOCK_T *lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_init_recursive(_LOCK_T *lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_close(_LOCK_T lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_close_recursive(_LOCK_T lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_acquire (_LOCK_T lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_acquire_recursive (_LOCK_T lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_release (_LOCK_T lock)
 {
   (void) lock;
 }
 
-void
+__attribute__ ((weak)) void
 __retarget_lock_release_recursive (_LOCK_T lock)
 {
   (void) lock;


### PR DESCRIPTION
The current strong implementation relies on the fact that the linker won't pick the functions from libc if all of them have already been implemented by the program. This allows allows a program to override them without them being strong.

However, this doesn't let another library overwrite them. The need to be marked as weak functions for that.