### PR TITLE
Revert "libc/misc: Mark lock functions as weak"

### DIFF
--- a/newlib/libc/misc/lock.c
+++ b/newlib/libc/misc/lock.c
@@ -81,52 +81,51 @@ struct __lock {
   char unused;
 };
 
-__attribute__ ((weak))
 struct __lock __lock___libc_recursive_mutex;
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_init (_LOCK_T *lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_init_recursive(_LOCK_T *lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_close(_LOCK_T lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_close_recursive(_LOCK_T lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_acquire (_LOCK_T lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_acquire_recursive (_LOCK_T lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_release (_LOCK_T lock)
 {
   (void) lock;
 }
 
-__attribute__ ((weak)) void
+void
 __retarget_lock_release_recursive (_LOCK_T lock)
 {
   (void) lock;


### PR DESCRIPTION
This reverts commit 196ddbac2be88b3fa88ee15bc7a6e68e5c516123.

Static library archives don't preserve information about which symbols are weak, so this couldn't work anyway.