### PR TITLE
Fix initfini regressions

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -212,7 +212,7 @@ option('picoexit', type: 'boolean', value: true,
        description: 'Smaller exit/atexit/onexit code')
 option('initfini-array', type: 'boolean', value: true,
        description: 'compiler supports INIT_ARRAY section types')
-option('initfini', type: 'boolean', value: false,
+option('initfini', type: 'boolean', value: true,
        description: 'Supports _init() and _fini()')
 option('crt-runtime-size', type: 'boolean', value: false,
        description: 'compute crt memory space sizes at runtime')

--- a/newlib/libc/misc/init.c
+++ b/newlib/libc/misc/init.c
@@ -33,7 +33,7 @@ __libc_init_array (void)
         _init ();
 
     fn = __init_array_start;
-    fn_end = __preinit_array_end;
+    fn_end = __init_array_end;
     while (fn != fn_end)
         (*fn++) ();
 #else


### PR DESCRIPTION
(1) picolibc introduced a discrepancy where the default value of `__INIT_FINI_FUNCS` is different between its CMake and Meson builds. Meson, which Wonderful uses, defaults to `false`. And when `__INIT_FINI_FUNCS` is false, picolibc relies on symbols `__bothinit_array_start/end` which are not defined by our linker scripts.
(2) And when `__INIT_FINI_FUNCS` *is* enabled, there's a nasty typo in the new implementation which causes only the `preinit` calls and not the `init` calls to get executed.

This PR fixes both issues, tested locally with a large C++ project.